### PR TITLE
Updated jquery.terminal to 2.35.1

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,9 +12,9 @@
     {{- partial "favicons.html" . }}
 
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.33.2/js/jquery.terminal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.35.1/js/jquery.terminal.min.js"></script>
     <script src="https://unpkg.com/jquery.terminal/js/autocomplete_menu.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.33.2/css/jquery.terminal.min.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.35.1/css/jquery.terminal.min.css" rel="stylesheet"/>
 
     <style>
         body {


### PR DESCRIPTION
The PR aims to resolve issue #2 

**Issue**: jquery.terminal had issues with mobile keypads for select browsers like firefox.

**Fix**: The v2.35.1 of jquery.terminal claims to have fixed this issue. Testing their demo website on firefox mobile app confirms this. Hence, updating the jquery.terminal version in this hugo theme should fix the issue.

**Files modified**: layouts/partials/head.html