### PR TITLE
Update index.html : certifications

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -159,6 +159,7 @@ params:
     - certName: Example Cert
       company: Example Certifying Company
       date: Date of Completion
+      badge: https://www.link.to.badge
       #description: Lorem Ipsum
   
   misc: 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -124,6 +124,9 @@ jQuery(document).ready(function($) {
             {{ if .description }}
             '{{ .description }}\n' +
             {{ end }}
+            {{ if .badge }}
+            'Badge: \t{{ .badge }}\n' +
+            {{ end }}
             '\r',
         {{ end }}
     {{ end }}


### PR DESCRIPTION
Most certifications come with a badge, so I added that option. In the certification details simply add 'badge: https://link.to.badge'