### PR TITLE
Added cli contact form + ascii captcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Live example at: <https://coolapso.sh>
 * Bootsequence:
   * Option for a custom bootsequence to mimic the boot process of the terminal
   * If the parameter is not set, the bootsequence is skipped.
+* CLI Contact Form
+  * Option for a contact form so visitors can message you
+  * Including customizable ascii captcha
+  * If no API is set to handle the message, the contact command is disabled
+    * Tested with AWS API, Lambda and AWS SES to handle the message, similar to [this](https://www.bomberbot.com/aws/how-to-build-a-serverless-contact-form-on-aws-ses-lambda-api-gateway/)
+  
 
 # How to start
 

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -50,6 +50,56 @@ params:
 
     Type 'help' for a list of available commands
 
+  contact:
+    # if mailAPI is empty, contact is disabled
+    mailAPI:
+    promptcolor: LemonChiffon
+    textcolor: orange
+    countercolor: lightblue
+    maxmessagechars: 300
+    ascTchas:
+      - image: |
+          ‎        .=     ,        =.
+          _  _   /'/    )\,/,/(_   \ \
+           `//-.|  (  ,\\)\//\)\/_  ) |
+           //___\   `\\\/\\/\/\\///'  /
+          ,"~`-._ `"--'_   `"""`  _ \`'"~-,_
+          \       `-.  '_`.      .'_` \ ,-"~`/
+           `.__.-'`/   (-\        /-) |-.__,'
+             ||   |     \o)  /^\ (o/  |
+             `\\  |         /   `\    /
+               \\  \       /      `\ /
+                `\\ `-.  /' .---.--.\
+                  `\\/`~(, '()      ('
+                   /(o) \\   _,.-.,_)
+                  //  \\ `\'`      /
+                / |  ||   `""""~"`
+               /'  |__||
+                     `o
+        question: "what can you drink from this creature?"
+        answers: ["milk", "urine"]
+      - image: |
+          ‎                            _
+                                    .' `'.__
+                                  /      \ `'"-,
+                  .-''''--...__..-/ .     |      \
+                .'               ; :'     '.  a   |
+              /                 | :.       \     =\
+              ;                   \':.      /  ,-.__;.-;`
+            /|     .              '--._   /-.7`._..-;`
+            ; |       '                |`-'      \  =|
+            |/\        .   -' /     /  ;         |  =/
+            (( ;.       ,_  .:|     | /     /\   | =|
+            ) / `\     | `""`;     / |    | /   / =/
+              | ::|    |      \    \ \    \ `--' =/
+              /  '/\    /       )    |/     `-...-`
+            /    | |  `\    /-'    /;
+            \  ,,/ |    \   d    .'  \
+            `""`   \  nnh  d_.-'l__nnh
+                      `"""`
+        question: "what is it you see?"
+        answers: ["elephant", "an elephant"]
+
   bootsequence: |
     User request detected
     Reserving Cloud Resources

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,6 +20,9 @@ jQuery(document).ready(function($) {
         {{ if .Site.Params.startxLocation }}
             startx: "starts graphical environment",
         {{ end }}
+        {{ if .Site.Params.contact.mailAPI }}
+            contact: "send a message",
+        {{ end }}
         {{ if .Site.Params.misc }}
             {{ .Site.Params.misc.commandName | default "other" }}: "{{.Site.Params.misc.title }}",
         {{ end }}
@@ -306,6 +309,213 @@ jQuery(document).ready(function($) {
             })();
         }
 
+        // function for human-check with randomly chosen ascii captcha's. 
+        function runASCtcha(callback) {
+
+          // select a random ascTcha
+          const ascTchas = JSON.parse('{{ .Site.Params.contact.ascTchas | jsonify | safeJS }}');
+          const rndmAscTcha = ascTchas[Math.floor(Math.random() * ascTchas.length)];
+
+          term.echo(`[[;{{ .Site.Params.contact.promptcolor }};]\nBefore we begin, please verify you\'re human.\n]`);
+          // show one of the images: 
+          term.echo('\n' + rndmAscTcha.image + '\n');
+          term.echo(`[[;{{ .Site.Params.contact.promptcolor }};]${rndmAscTcha.question}]`);
+
+          // ask and check answer
+          term.push(function(answer) {
+            if (rndmAscTcha.answers.includes(answer.trim().toLowerCase())) {
+              term.echo('[[b;green;]ASCtcha passed]');
+              term.echo(`[[;{{ .Site.Params.contact.promptcolor }};]You seem human enough, let's continue :) \n]`);
+              term.pop();
+              callback(); // continue the form or process
+            } else {
+              term.echo('[[b;red;]Incorrect...] [[;orange;]Are you sure you are human?]\nReturning to prompt');
+              term.pop();
+              return;
+            }
+          }, {
+            prompt: '[[;{{ .Site.Params.contact.promptcolor }};]Answer:  ]'
+          });
+        }
+
+        // if human; then contact
+        function contact () {
+          let index = 0;
+
+          // set the questions: 
+          var settings = {};
+          var questions = [
+            {
+              name: "name",
+              prompt: 'Enter your name: '
+            },
+            {
+              name: "email",
+              prompt: 'Enter your email address: '
+            },
+            {
+              name: "message",
+              prompt: 'Enter your message (type [[;{{ .Site.Params.contact.textcolor }};]END] on a new line to finish): '
+            },
+            {
+              name: "spambot",
+              prompt: 'Are you a spambot? (Y)es/(N)o ',
+              boolean: true
+            }
+          ];
+
+          // save prompt
+          const defaultPrompt = term.get_prompt();
+
+          // function to allow multiline message
+          function getMultilineInput(callback) {
+            let message = '';
+
+            const updatePrompt = (count) => `[[;{{ .Site.Params.contact.countercolor }};] ${count.toString().padStart(3, '0')}/{{ .Site.Params.contact.maxmessagechars }}] [[;{{ .Site.Params.contact.promptcolor }};]> ] `;
+            term.push(function handler(line) {
+              if (line.trim() === 'END') {
+                term.pop();
+                callback(message.trim());
+                return;
+              }
+              if ((message + line + '\n').length > {{ .Site.Params.contact.maxmessagechars }}) {
+                term.echo(`[[b;red;]Message too long! Max {{ .Site.Params.contact.maxmessagechars }} characters.]`);
+                return;
+              }
+              message += line + '\n';
+              term.set_prompt(updatePrompt(message.length));
+            }, {
+              prompt: updatePrompt(0),
+              name: 'message_input',
+            });
+          }
+
+          // ask questions
+          function ask_questions(step) {
+            var question = questions[step];
+            if (question) {
+              if (question.name === "message") {
+                term.echo(`[[;{{ .Site.Params.contact.promptcolor }};]${question.prompt}]`);
+                getMultilineInput((message) => {
+                  settings[question.name] = message;
+                  term.set_prompt(defaultPrompt);
+                  ask_questions(step + 1);
+                });
+                return;
+              }
+              term.push(function(command) {
+                if (question.boolean) {
+                  var value;
+                  if (command.match(/^Y(es)?/i)) {
+                    value = true;
+                  } else if (command.match(/^N(o)?/i)) {
+                    value = false;
+                  } else {
+                    value = true; 
+                  }
+                  settings[question.name] = value;
+                  term.pop();
+                  ask_questions(step+1);
+                } else {
+                  settings[question.name] = command;
+                  term.pop();
+                  ask_questions(step+1);
+                }
+              }, {
+                prompt: `[[;{{ .Site.Params.contact.promptcolor }};]${question.prompt || question.name + ": "}]`,
+              });
+            } else {
+              check();
+            }
+          }
+
+          // check answers
+          function check() {
+            term.echo(`\n[[;{{ .Site.Params.contact.promptcolor }};]Your settings:]`);
+            const str = Object.keys(settings).map(function(key) {
+              const value = settings[key];
+              return `[[b;{{ .Site.Params.contact.promptcolor }};]${key}]: [[;{{ .Site.Params.contact.textcolor }};]${value}]`;
+            }).join('\n');
+            term.echo(str);
+
+            term.push(function(command) {
+              if (command.match(/^y$/i)) {
+                const errors = [];
+
+                if (!settings.name || settings.name.trim() === '') {
+                  errors.push(' --> [[b;red;]Name is required.]');
+                }
+
+                if (!settings.email || !settings.email.match(/^[^@\s]+@[^@\s]+\.[^@\s]+$/)) {
+                  errors.push(' --> [[b;red;]The email address appears to be invalid.]');
+                }
+
+                if (!settings.message || settings.message.trim() === '') {
+                  errors.push(' --> [[b;red;] Message cannot be empty.]');
+                }
+
+                if (settings.message.length > {{ .Site.Params.contact.maxmessagechars }}) {
+                  errors.push(` --> [[b;red;]Message exceeds {{ .Site.Params.contact.maxmessagechars }} characters.]`);
+                }
+
+                if (settings.spambot !== false) {
+                  errors.push(' --> [[b;red;]You appear to be a spambot...]');
+                }
+
+                if (errors.length > 0) {
+                  term.echo('[[b;red;]Some issues were found:]');
+                  errors.forEach(err => term.echo(err));
+                  term.echo('Returning to prompt...');
+                  term.set_prompt(defaultPrompt);
+                  term.pop().history().enable();
+                  return;
+                }
+
+                settings.source = 'terminalcv-contact';
+
+                const filtered = Object.fromEntries(
+                  Object.entries(settings).filter(([key]) => !['spambot'].includes(key))
+                );
+
+                term.echo('[[b;green;]Thanks! Message looks good.]');
+                sendContactData(settings);
+                term.set_prompt(defaultPrompt);
+                term.pop().history().enable();
+
+              } else if (command.match(/^n$/i)) {
+                term.pop();
+                ask_questions(0);
+              } else {
+                term.echo(`[[;{{ .Site.Params.contact.promptcolor }};]Please enter 'y' or 'n']`);
+              }
+            }, {
+              prompt: `[[;{{ .Site.Params.contact.promptcolor }};]Does this look send-worthy? (y|n): ]`,
+            });
+          }
+
+          // send message via API
+          function sendContactData(data) {
+            fetch('{{ .Site.Params.contact.mailAPI }}', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(data)
+            })
+            .then(res => res.json())
+            .then(response => {
+              term.echo('[[b;green;]--> Message sent!]');
+            })
+            .catch(err => {
+              console.error(err);
+              term.echo('[[b;red;]--> Failed to send message. Try again later.]');
+            });
+          }
+
+          term.history().disable();
+          ask_questions(0);
+        }
+
         commands = command.split(/[ ]+/);
         if (commands[0] == 'less') {
             useLess = true;
@@ -372,6 +582,15 @@ jQuery(document).ready(function($) {
                 useLess = true;
                 {{ end }}
                 echoArray(misc);
+                break;
+            case 'contact':
+                //check for API, then for human, then process contact
+                {{ if .Site.Params.contact.mailAPI }}
+                  term.clear();
+                  runASCtcha(function() {
+                    contact(); 
+                  });
+                {{ end }}
                 break;
             case 'help':
             case '?':


### PR DESCRIPTION
Hi Carlos, 

I've added an option for a cli contact form, including ascii captcha's (ascTcha is what I call it 😉). 

I've used such a form on my old site and wanted one via terminalCV. I took https://terminal.jcubic.pl/examples.php#questions as an example and built from there.  It has the following built in: 
- human check via ascii captcha (ascTcha). It randomly selects one from an array in config.yml. Two are added as an example. 
- interaction to ask for name, email, message and a trivial spambot question
- multi line message. Message must be finished with 'END'. 
- message character counter while typing (well, it refreshes on a newline). Max can be set in config, currently 300
- contact command is only enabled if an API link is configured. I've tested it with an API from AWS API Gateway. AWS Lambda handles the message and sends the message to me via AWS SES. This [blogpost](https://www.bomberbot.com/aws/how-to-build-a-serverless-contact-form-on-aws-ses-lambda-api-gateway/) explains the process in detail.
- colors are all configurable, except the errors (red) and approval (green) 
- Checks are included to validate the email address, mandatory fields (which are all of them) and message length

I've updated the examplesite config and added a screenshot to give an idea of how it looks. 

Please let me know what you think 😁

Cheers,

David

<img width="449" alt="image" src="https://github.com/user-attachments/assets/6e9c3210-b8b6-4775-a2f8-02a8b702fc72" />


