### PR TITLE
added toggle for *nixlike ls output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Live example at: <https://coolapso.sh>
 
 - Blogging:
   - Toggle support, don't want blog features? just disable them!
+  - Toggle for \*nixlike ls output
   - Support for images
   - Supoort for [hugo shortcodes](https://gohugo.io/content-management/shortcodes/) (not fully tested, but should work!)
 - Custom Greeting

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ Live example at: <https://coolapso.sh>
   - **version:** Shows the website version
     - Disabled by default
     - only enabled if provided a version parameter
-- Less, print commands output with less
+- Less, print commands and posts (if blogging is enabled) output with less
   - Global, all commands use less instead of standard output
   - Per command, only defined commands use less as output method
   - `less <command>`, will output using less instead of standard output
+  - `less <post>`, will output using less instead of standard output
 - Command auto completion
 - Cat <post> auto completion
 - progression bars can be interrupted by pressing `ctrl+d`

--- a/README.md
+++ b/README.md
@@ -13,66 +13,68 @@ Live example at: <https://coolapso.sh>
 
 # Features
 
-* Blogging:
-  * Toggle support, don't want blog features? just disable them!
-  * Support for images
-  * Supoort for [hugo shortcodes](https://gohugo.io/content-management/shortcodes/) (not fully tested, but should work!)
-* Custom Greeting
-  * Multi line text is respected
-* Customizable prompt
-  * Custom before & after prompt text
-  * Custom before & after prompt colors
-  * Custom prompt text
-  * Custom prompt text Color
-  * custom separator text
-  * custom separator color
-  * custom before & after symbols text
-  * custom before & after symbols colors
-  * Custom symbols
-  * Custom symbols color
-  * Custom extra text
-  * Custom extra text color
-* Multiple sections with individual commands:
-  * **Whois:** General information about the individual
-  * **social:** shows social networks
-    * Any social network is supported, even the ones that don't exist! just provide a name and a URL
-    * The social network name can be hidden and show only the URL
-  * **work:** shows work experience information
-  * **education:** shows education information
-  * **sklls:** Shows skills information
-  * **softskills:** shows softskills information
-  * **languages:** Shows languages skills information
-  * **projects:** Shows projects information
-  * **certifications:** Shows certifications information
-  * **publications:** Shows publications information
-  * **misc:** Free text
-    * misc command can be overriden and given another name
-    * Title can have custom color
-    * Content can have custom color
-  * each section have multiple configuration options, see the [config.yml](config.yml) for more details
-* Extra commands:
-  * **startx:** Shows "loading..." progress bar and redirects to another website
-    * Disabled by default
-    * only enabled if provided a location to send to
-  * **exit:** Shows "terminating..." progress bar and redirects to another website
-    * Disabled by default
-    * only enabled if provided a location to send to
-  * **source:** Shows the glider and the theme github repo URL
-    * Enabled by default
-    * Can be disabled
-  * **version:** Shows the website version
-    * Disabled by default
-    * only enabled if provided a version parameter
-* Less, print commands output with less
-  * Global, all commands use less instead of standard output
-  * Per command, only defined commands use less as output method
-  * `less <command>`, will output using less instead of standard output
-* Command auto completion
-* progression bars can be interrupted by pressing `ctrl+d`
-* Favicons
-* Bootsequence:
-  * Option for a custom bootsequence to mimic the boot process of the terminal
-  * If the parameter is not set, the bootsequence is skipped.
+- Blogging:
+  - Toggle support, don't want blog features? just disable them!
+  - Support for images
+  - Supoort for [hugo shortcodes](https://gohugo.io/content-management/shortcodes/) (not fully tested, but should work!)
+- Custom Greeting
+  - Multi line text is respected
+  - Separate banner with different color is supported
+- Customizable prompt
+  - Custom before & after prompt text
+  - Custom before & after prompt colors
+  - Custom prompt text
+  - Custom prompt text Color
+  - custom separator text
+  - custom separator color
+  - custom before & after symbols text
+  - custom before & after symbols colors
+  - Custom symbols
+  - Custom symbols color
+  - Custom extra text
+  - Custom extra text color
+- Multiple sections with individual commands:
+  - **Whois:** General information about the individual
+  - **social:** shows social networks
+    - Any social network is supported, even the ones that don't exist! just provide a name and a URL
+    - The social network name can be hidden and show only the URL
+  - **work:** shows work experience information
+  - **education:** shows education information
+  - **sklls:** Shows skills information
+  - **softskills:** shows softskills information
+  - **languages:** Shows languages skills information
+  - **projects:** Shows projects information
+  - **certifications:** Shows certifications information
+  - **publications:** Shows publications information
+  - **misc:** Free text
+    - misc command can be overriden and given another name
+    - Title can have custom color
+    - Content can have custom color
+  - each section have multiple configuration options, see the [config.yml](config.yml) for more details
+- Extra commands:
+  - **startx:** Shows "loading..." progress bar and redirects to another website
+    - Disabled by default
+    - only enabled if provided a location to send to
+  - **exit:** Shows "terminating..." progress bar and redirects to another website
+    - Disabled by default
+    - only enabled if provided a location to send to
+  - **source:** Shows the glider and the theme github repo URL
+    - Enabled by default
+    - Can be disabled
+  - **version:** Shows the website version
+    - Disabled by default
+    - only enabled if provided a version parameter
+- Less, print commands output with less
+  - Global, all commands use less instead of standard output
+  - Per command, only defined commands use less as output method
+  - `less <command>`, will output using less instead of standard output
+- Command auto completion
+- progression bars can be interrupted by pressing `ctrl+d`
+- Favicons
+- Bootsequence:
+  - Option for a custom bootsequence to mimic the boot process of the terminal
+  - If the parameter is not set, the bootsequence is skipped.
+
 # How to start
 
 This theme is far more simplistic than most themes therefore running `hugo new site` creates a lot of things that are not necessary.
@@ -91,7 +93,7 @@ Now you can start personalizing it by changing the config.yml and when you are h
 
 If you are using git (which you should be!) for your website and don't want to make any radical changes to the theme itself, it's recommended that you add the theme as a submodule. This way, you can easily get new updates when they are available.
 
-``` bash
+```bash
 git submodule add https://github.com/coolapso/hugo-theme-terminalcv.git themes/terminalcv
 ```
 
@@ -114,12 +116,9 @@ params:
   blog: true
 ```
 
-The theme supports blog posts, site visitors can find the posts with the `posts` or `ls` commands, and can view posts with `cat <filename>` to see how it works you can read the [example post](/exampleSite/content/posts/examplepost/index.md). 
-
-
+The theme supports blog posts, site visitors can find the posts with the `posts` or `ls` commands, and can view posts with `cat <filename>` to see how it works you can read the [example post](/exampleSite/content/posts/examplepost/index.md).
 
 ![terminalCV](https://raw.githubusercontent.com/coolapso/hugo-theme-terminalcv/main/images/blogdemo.gif)
-
 
 The live demo may not be making use of the blogging capabilities, but you can always see it in action like this:
 
@@ -132,7 +131,7 @@ cd hugo-theme-terminalcv
 make server
 ```
 
-Now a demo will be available at http://localhost:1313
+Now a demo will be available at <http://localhost:1313>
 
 # Contributions
 
@@ -168,6 +167,6 @@ terminalCV makes use [jcubic/jquery.terminal](https://github.com/jcubic/jquery.t
 
 Let me know and feel free to open a Pull Request and add it to this list:
 
-|link                 | Description       |
-|---------------------|-------------------|
-|<https://coolapso.sh>  | Simple CV         |
+| link                  | Description |
+| --------------------- | ----------- |
+| <https://coolapso.sh> | Simple CV   |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Live example at: <https://coolapso.sh>
   - Per command, only defined commands use less as output method
   - `less <command>`, will output using less instead of standard output
 - Command auto completion
+- Cat <post> auto completion
 - progression bars can be interrupted by pressing `ctrl+d`
 - Favicons
 - Bootsequence:

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -6,7 +6,9 @@ title: "terminalcv"
 params:
   version: "2.0.0"
   description: "My terminal cv"
-  blog: true
+  blog: 
+    enabled: true
+    lsClassic: true
   prompt:
     core:
       text: "user@terminalCV"

--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -40,7 +40,8 @@ params:
   exitMessage: "[Session completed, the browserwindow can be safely closed]"
   source: true
   #use a ‎ (blank character) if your first character of the ascii art is a whitespace
-  greeting: |
+  greetingbannercolor: white
+  greetingbanner: |
     ‎ _                      _             _  _______      __
     | |                    (_)           | |/ ____\ \    / /
     | |_ ___ _ __ _ __ ___  _ _ __   __ _| | |     \ \  / / 
@@ -48,6 +49,7 @@ params:
     | ||  __/ |  | | | | | | | | | | (_| | | |____   \  /   
      \__\___|_|  |_| |_| |_|_|_| |_|\__,_|_|\_____|   \/
 
+  greeting: |
     Welcome to my online resume
 
     Type 'help' for a list of available commands

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,24 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content in {{ .Title }} on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ .Site.LanguageCode }}</language>
+    <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    <atom:link href="{{ .Permalink }}index.xml" rel="self" type="application/rss+xml" />
+    {{- range .Pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <author>{{ .Params.author | default "unknown" }}</author>
+      {{ with .File }}<filename>{{ path.BaseName .Dir }}</filename>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>
+

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,12 +49,10 @@ jQuery(document).ready(function($) {
         {{ if .Site.Params.exitLocation }}
             exit: "exit the terminal",
         {{ end }}
-        {{ if .Site.Params.blog }}
-        posts: "List all posts",
-        {{ if .Site.Params.listLS }}
-        ls: "List all posts",
-        {{ end }}
-        cat: "Open a post",
+        {{ if .Site.Params.blog.enabled }}
+            posts: "List all posts",
+            ls: "List all posts",
+            cat: "Open a post",
         {{ end }}
         all: "Show all details about me",
     };
@@ -137,6 +135,40 @@ jQuery(document).ready(function($) {
     };
 
     function posts(term) {
+      {{ if .Site.Params.blog.lsClassic }}
+        // classic ls output
+        $.ajax({
+            url: "posts/index.xml",
+            type: 'GET',
+            dataType: 'xml',
+            success: function(xml) {
+                // let output = 'To read a post do: cat filename\n';
+                let output = '\n';
+                
+                $(xml).find('item').each(function() {
+                    let title = $(this).find('title').text();
+                    let filename = $(this).find('filename').text();
+                    let author = $(this).find('author').text() || "unknown";
+                    let pubDate = $(this).find('pubDate').text();
+                    
+                    let dateObj = new Date(pubDate);
+                    let date = dateObj.toLocaleDateString('en-US', { 
+                        year: 'numeric', 
+                        month: 'short', 
+                        day: '2-digit' 
+                    });
+                    let line = `-r--r--r--  ${author.padEnd(12)}  ${date.padEnd(13)}  ${filename}`;
+                    output += line + '\n';
+                });
+                
+                term.echo(output);
+            },
+            error: function() {
+            term.echo("Error: Could not load posts data");
+            }
+        });
+      {{ else }}
+        // Original output
         $.ajax({
             url: "posts/",
             type: 'GET',
@@ -147,8 +179,8 @@ jQuery(document).ready(function($) {
                 term.echo("Error: Could not load posts data");
             }
         });
-    };
-
+      {{ end }}
+    }
 
     function catPost(term, postdir) {
         url = "/posts/" + postdir + "/";
@@ -163,6 +195,7 @@ jQuery(document).ready(function($) {
             }
         });
     }
+
     var certifications = [
     {{ with .Site.Params.certifications.details }}
         {{ range . }}
@@ -540,7 +573,7 @@ jQuery(document).ready(function($) {
                 term.echo("{{ .Site.Params.version }}");
                 break;
             {{ end }}
-            {{ if .Site.Params.blog }}
+            {{ if .Site.Params.blog.enabled }}
             case 'cat':
                 if (commands.length < 2) {
                     term.echo("Usage: cat <filename>");

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -52,18 +52,17 @@ jQuery(document).ready(function($) {
         {{ if .Site.Params.blog.enabled }}
             posts: "List all posts",
             ls: "List all posts",
-            cat: "Open a post",
+            cat: {
+                description: "Open a post",
+                args: [
+                    {{ range where .Site.RegularPages "Section" "posts" }}
+                    "{{ with .File }}{{ path.BaseName .Dir }}{{ end }}",
+                    {{ end }}
+                ]
+            },
         {{ end }}
         all: "Show all details about me",
     };
-
-    {{ if .Site.Params.blog.enabled }}
-    var postFilenames = [
-        {{ range where .Site.Pages "Section" "posts" }}
-        "{{ with .File }}{{ path.BaseName .Dir }}{{ end }}",
-        {{ end }}
-    ];
-    {{ end }}
 
     function progressBar(number) {
         var barLength = Math.round(number / 10);
@@ -445,13 +444,13 @@ jQuery(document).ready(function($) {
             })();
         }
 
-        commands = command.split(/[ ]+/);
-        if (commands[0] == 'less') {
+        cmdParts = command.split(/[ ]+/);
+        if (cmdParts[0] == 'less') {
             useLess = true;
-            commands.shift();
+            cmdParts.shift();
         } 
                     
-        switch(commands[0]) {
+        switch(cmdParts[0]) {
             case 'whois':
                 {{ if .Site.Params.whois.settings.useLess }}
                 useLess = true;
@@ -583,10 +582,10 @@ jQuery(document).ready(function($) {
             {{ end }}
             {{ if .Site.Params.blog.enabled }}
             case 'cat':
-                if (commands.length < 2) {
+                if (cmdParts.length < 2) {
                     term.echo("Usage: cat <filename>");
                 } else {
-                    var  postdir = commands[1];
+                    var  postdir = cmdParts[1];
                     catPost(term, postdir);
                 }
                 break;
@@ -601,6 +600,7 @@ jQuery(document).ready(function($) {
                 term.echo("\nunknown command: " + command + "\n" +
                           "please type 'help' or '?' for a list of available commands\n");
         }
+
     }, {
 
         {{ if .Site.Params.bootsequence }} 
@@ -637,7 +637,26 @@ jQuery(document).ready(function($) {
         },
         autocompleteMenu: true,
         {{ if .Site.Params.blog.enabled }}
-          completion: Object.keys(commands).concat(postFilenames)
+          // own completion funciton with arguments support
+          completion: function(string) {
+              var command = this.get_command();
+              var parts = command.split(/\s+/);
+              var commandName = parts[0];
+              
+              // Complete command names
+              if (parts.length === 1 || command.indexOf(' ') === -1) {
+                  return Object.keys(commands).filter(function(cmd) {
+                      return cmd.startsWith(string);
+                  });
+              }
+              
+              // Arguments part for any command which has them
+              if (commands[commandName] && commands[commandName].args) {
+                  return commands[commandName].args.filter(function(arg) {
+                      return arg.startsWith(string);
+                  });
+              }
+          }
         {{ else }}
           completion: Object.keys(commands)
         {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,9 +3,37 @@
 jQuery(document).ready(function($) {
     var animation = false;
 
+    var postFilenames = [
+        {{ range where .Site.RegularPages "Section" "posts" }}
+        "{{ with .File }}{{ path.BaseName .Dir }}{{ end }}",
+        {{ end }}
+    ];
+
+    var lessCommands = [
+        "whois",
+        {{ if .Site.Params.social }}"social",{{ end }}
+        {{ if .Site.Params.work }}"work",{{ end }}
+        {{ if .Site.Params.education }}"education",{{ end }}
+        {{ if .Site.Params.skills }}"skills",{{ end }}
+        {{ if .Site.Params.softSkills }}"softskills",{{ end }}
+        {{ if .Site.Params.languages }}"languages",{{ end }}
+        {{ if .Site.Params.projects }}"projects",{{ end }}
+        {{ if .Site.Params.publications }}"publications",{{ end }}
+        {{ if .Site.Params.certifications }}"certifications",{{ end }}
+        {{ if .Site.Params.misc }}"{{ .Site.Params.misc.commandName | default "other" }}",{{ end }}
+        {{ if not .Site.Params.Source }}"source",{{ end }}
+        "all"
+    ];
+
     var commands = {
         help: "shows help",
-        less: "Use less as output method",
+        less: {
+            description: "Use less as output method for commands",
+            args: [
+                ...lessCommands{{ if .Site.Params.blog.enabled }},
+                ...postFilenames{{ end }}
+            ]
+        },
         whois: "list basic details",
         {{ if .Site.Params.social }}
         social: "list social networks",
@@ -54,12 +82,8 @@ jQuery(document).ready(function($) {
             ls: "List all posts",
             cat: {
                 description: "Open a post",
-                args: [
-                    {{ range where .Site.RegularPages "Section" "posts" }}
-                    "{{ with .File }}{{ path.BaseName .Dir }}{{ end }}",
-                    {{ end }}
-                ]
-            },
+                args: postFilenames
+             },
         {{ end }}
         all: "Show all details about me",
     };
@@ -82,16 +106,22 @@ jQuery(document).ready(function($) {
 
         let helpText = ""
         for (let key in commands) {
-            if (commands.hasOwnProperty(key)) {
-                helpText += ` ${padKey(key, longestKeyLength)}\t${commands[key]}\n`
-            }
+          if (commands.hasOwnProperty(key)) {
+              commandValue = commands[key];
+              description = typeof commandValue === 'string' ? commandValue : commandValue.description;
+              helpText += ` ${padKey(key, longestKeyLength)}\t${description}\n`
+          }
         }
         return helpText
     }
 
     var help = '\n[[b;white;]usage:]\n' +
-                '\n <command> - execute the command\n' +
-                ' less <command> - use less to display the output\n\n' +
+                '\n <command>'.padEnd(17) + '- execute the command\n' +
+                ' less <command>'.padEnd(16) + '- use less to display the output\n\n' +
+                {{ if .Site.Params.blog.enabled }}
+                  ' less <post>'.padEnd(16) + '- use less to display a post\n' +
+                  ' cat <post>'.padEnd(16) + '- use cat to print a post\n' +
+                {{ end }}
                 '\n[[b;white;]Available commands:]\n' + 
                commandsHelp();
 
@@ -187,20 +217,6 @@ jQuery(document).ready(function($) {
             }
         });
       {{ end }}
-    }
-
-    function catPost(term, postdir) {
-        url = "/posts/" + postdir + "/";
-        $.ajax({
-            url: url,
-            type: 'GET',
-            success: function(data) {
-                term.echo(data, {raw: true});
-            },
-            error: function() {
-                term.echo("Error: Could not load post " + postdir);
-            }
-        });
     }
 
     var certifications = [
@@ -390,26 +406,57 @@ jQuery(document).ready(function($) {
     ]
 
     $('body').terminal(function(command, term) {
-
+  
         var useLess = false;
         {{if .Site.Params.useLess }}
         useLess = true;
         {{ end }}
 
-        function echoArray(array) {
+        function echoArray(array, options) {
+            var opts = options || {};
+            
             if (useLess) {
-                term.less(array, {
-                    onExit: function () {
-                        term.set_command('');
-                        term.scroll_to_bottom();
-                    },
-                });
+                if (opts.raw) {
+                    var content = array[0];
+                    var export_data = term.export_view();
+                    
+                    term.clear();
+                    term.echo(content, {raw: true});
+                    
+                    term.push(function(command) {}, {
+                        prompt: ':',
+                        keydown: function(e) {
+                            if (e.which === 81 || e.which === 113) { // Q
+                                term.pop();
+                                term.import_view(export_data);
+                                return false;
+                            }
+                        }
+                    });
+                } else {
+                    term.less(array);
+                }
             } else {
                 for (i = 0; i < array.length; i += 1) {
-                    term.echo(array[i]);
+                    term.echo(array[i], options || {});
                 }
             }
         }
+
+        function catPost(term, postdir) {
+        url = "/posts/" + postdir + "/";
+        $.ajax({
+            url: url,
+            type: 'GET',
+            success: function(data) {
+                // term.echo(data, {raw: true});
+                echoArray([data], {raw: true});
+            },
+            error: function() {
+                term.echo("Error: Could not load post " + postdir);
+            }
+        });
+    }
         //Function used by StartX to draw the progressBar
         function progress(percent, width) {
             var size = Math.round(width*percent/100);
@@ -448,6 +495,17 @@ jQuery(document).ready(function($) {
         if (cmdParts[0] == 'less') {
             useLess = true;
             cmdParts.shift();
+
+            let target = cmdParts[0];
+
+            if (!target) { 
+                term.echo("less: missing argument");
+                return;
+            } else if (postFilenames.includes(target)) {
+                // its a blogpost
+                catPost(term, target);
+                return;
+            } 
         } 
                     
         switch(cmdParts[0]) {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -57,6 +57,14 @@ jQuery(document).ready(function($) {
         all: "Show all details about me",
     };
 
+    {{ if .Site.Params.blog.enabled }}
+    var postFilenames = [
+        {{ range where .Site.Pages "Section" "posts" }}
+        "{{ with .File }}{{ path.BaseName .Dir }}{{ end }}",
+        {{ end }}
+    ];
+    {{ end }}
+
     function progressBar(number) {
         var barLength = Math.round(number / 10);
         var barFilled = Array(barLength + 1).join("&#9611;");
@@ -628,7 +636,11 @@ jQuery(document).ready(function($) {
             }
         },
         autocompleteMenu: true,
-        completion: Object.keys(commands)
+        {{ if .Site.Params.blog.enabled }}
+          completion: Object.keys(commands).concat(postFilenames)
+        {{ else }}
+          completion: Object.keys(commands)
+        {{ end }}
         
     });
 });

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -668,8 +668,8 @@ jQuery(document).ready(function($) {
           term.typing('echo', 1, '{{ .Site.Params.bootsequence }}', function() {
             term.clear();
             {{ if .Site.Params.greetingbanner }}
-              term.echo("[[b;{{ .Site.Params.greetingBannerColor | default "coral" }};]{{ .Site.Params.greetingBanner }}{{ .Site.Params.version }}]");
-              term.echo("[[b;{{ .Site.Params.greetingColor | default "green" }};]{{ .Site.Params.greeting }}]");
+              term.echo("[[b;{{ .Site.Params.greetingBannerColor | default "white" }};]{{ .Site.Params.greetingBanner }}{{ .Site.Params.version }}]");
+              term.echo("[[b;{{ .Site.Params.greetingColor | default "white" }};]{{ .Site.Params.greeting }}]");
             {{ else }}
               term.echo("[[b;{{ .Site.Params.greetingColor | default "white" }};]{{ .Site.Params.greeting }}]");
             {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -568,7 +568,12 @@ jQuery(document).ready(function($) {
           term.pause();
           term.typing('echo', 1, '{{ .Site.Params.bootsequence }}', function() {
             term.clear();
-            term.echo("[[b;{{ .Site.Params.greetingColor | default "white" }};]{{ .Site.Params.greeting }}]");
+            {{ if .Site.Params.greetingbanner }}
+              term.echo("[[b;{{ .Site.Params.greetingBannerColor | default "coral" }};]{{ .Site.Params.greetingBanner }}{{ .Site.Params.version }}]");
+              term.echo("[[b;{{ .Site.Params.greetingColor | default "green" }};]{{ .Site.Params.greeting }}]");
+            {{ else }}
+              term.echo("[[b;{{ .Site.Params.greetingColor | default "white" }};]{{ .Site.Params.greeting }}]");
+            {{ end }}
           });
           term.resume();
           },

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -145,7 +145,7 @@ jQuery(document).ready(function($) {
       {{ if .Site.Params.blog.lsClassic }}
         // classic ls output
         $.ajax({
-            url: "posts/index.xml",
+            url: "/posts/index.xml",
             type: 'GET',
             dataType: 'xml',
             success: function(xml) {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,11 +12,11 @@
     {{- partial "favicons.html" . }}
 
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.42.2/js/jquery.terminal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.45.2/js/jquery.terminal.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/less.min.js"></script>
     <script src="https://unpkg.com/jquery.terminal/js/autocomplete_menu.js"></script>
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.42.0/css/jquery.terminal.min.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.45.2/css/jquery.terminal.min.css" rel="stylesheet"/>
 
     <style>
         body {


### PR DESCRIPTION
Hi Carlos, 

I've added a toggle to enable *nixlike ls output. The default output is a bit too much, for my taste, especially if there are more than a few blogposts. 

Files changed:
- layouts/index.html > expanded posts function
- layouts/_defaults/rss.xml > I first created a separate json file, but then noticed that the rss xml files were already created anyway. Only the author and filename was missing. So I added this file to fix that and use the xml file in posts to get the data for ls. 
- examplesite/config.yml > changed the blog params a bit: added enabled, added lsClassic, removed listLS. I removed listLS as it only was used to list ls in the help section. 
- README.md > added a toggle line. 

Cheers,

David